### PR TITLE
Document JUCE setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+project(PrismVST)
+
+option(JUCE_DIR "Path to the JUCE framework" "${CMAKE_SOURCE_DIR}/../JUCE")
+
+if(NOT EXISTS ${JUCE_DIR})
+    message(FATAL_ERROR "JUCE not found at ${JUCE_DIR}. Set JUCE_DIR to your JUCE directory.")
+endif()
+
+# TODO: add plugin targets that use JUCE
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Prism-VST-Plugin
+
+This repository contains a JUCE-based audio plug-in named *Prism*.
+
+## Build
+
+1. Download the JUCE framework separately. The source must be placed in a
+   directory named `JUCE` located next to this repository (i.e. `../JUCE`),
+   or add JUCE as a git submodule at that location.
+2. Prism currently requires **JUCE 7 or later**.
+3. Configure the project with CMake. You can optionally specify the path to JUCE
+   using the `JUCE_DIR` option:
+
+```bash
+cmake -S . -B build -D JUCE_DIR=/path/to/JUCE
+cmake --build build
+```
+
+If `JUCE_DIR` is not provided, CMake will look for JUCE in `../JUCE` by
+default.


### PR DESCRIPTION
## Summary
- expand README with build instructions
- add minimal CMakeLists with `JUCE_DIR` option

## Testing
- `cmake -S . -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859941dcd08832a8b8cc01960a7036e